### PR TITLE
fix: fix project not building for version > 7.4.0

### DIFF
--- a/react-native-startup-trace/ios/StartupTrace.h
+++ b/react-native-startup-trace/ios/StartupTrace.h
@@ -9,7 +9,7 @@
 #import “React/RCTBridgeModule.h” // Required when used as a Pod in a Swift project
 #endif
 
-@import FirebasePerformance;
+#import <Firebase/Firebase.h>
 
 @interface StartupPerformanceTrace : NSObject <RCTBridgeModule>
 

--- a/react-native-startup-trace/package.json
+++ b/react-native-startup-trace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-startup-trace",
   "title": "React Native Startup Trace",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Measure RN app startup trace with Firebase performance",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Fixes #5 

Firebase performance iOS SDK changed a lot of things from version 7.3.0 to version 7.4.0 which broke this import.
Which made this module not compatible with versions of react-native-firebase >= 10.5.0

Tested a brand new project with latest version of react-native-firebase and it works:

![image](https://user-images.githubusercontent.com/4534323/116870811-80314200-ac13-11eb-95a2-0252ba0ca49e.png)
